### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JostBrand/jsonshiatsu/security/code-scanning/3](https://github.com/JostBrand/jsonshiatsu/security/code-scanning/3)

To fix the problem, add a `permissions` block with the minimal required scope—almost always `contents: read`—at the top level of the workflow file, so it applies to all jobs unless overridden. This should be inserted in the YAML file after the workflow `name:` and before `on:`. This change will prevent the GitHub Actions token from having more access than necessary, conforming to the principle of least privilege. No changes to any job's internals are required unless certain steps need additional permissions (which is not apparent here; the actions here only check out code and run tests, none of which require elevated permissions).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
